### PR TITLE
Configure proxy to change origin

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,11 +33,11 @@ if (process.env.FISSION_LOGDB !== undefined) {
 }
 
 // Setup proxy for fission APIs
-app.use('/proxy/controller', proxy({ target: `http://${controllerBackend}`, pathRewrite: { '^/proxy/controller': '' } }));
-app.use('/proxy/router', proxy({ target: `http://${routerBackend}`, pathRewrite: { '^/proxy/router': '' } }));
+app.use('/proxy/controller', proxy({ target: `http://${controllerBackend}`, pathRewrite: { '^/proxy/controller': '' }, changeOrigin: true }));
+app.use('/proxy/router', proxy({ target: `http://${routerBackend}`, pathRewrite: { '^/proxy/router': '' }, changeOrigin: true }));
 app.use('/proxy/tpr/benchmark', proxy({ target: `http://${k8sBackend}`,
-  pathRewrite: { '^/proxy/tpr/benchmark': '/apis/benchmark.fission.io/v1/namespaces/fission-benchmark' } }));
-appInfluxdb.use('', proxy({ target: `http://${influxdbBackend}` }));
+  pathRewrite: { '^/proxy/tpr/benchmark': '/apis/benchmark.fission.io/v1/namespaces/fission-benchmark' }, changeOrigin: true }));
+appInfluxdb.use('', proxy({ target: `http://${influxdbBackend}`, changeOrigin: true }));
 
 // In production we need to pass these values in instead of relying on webpack
 setup(app, {


### PR DESCRIPTION
Change origin is needed when the router and controllers are behind a proxy such as nginx.